### PR TITLE
Implement homepage wireframe

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,12 @@
-# PostPal Frontend  
-Just getting started. 👻
+# PostPal Frontend
+
+This repository contains a simple HTML prototype for the PostPal homepage.
+The `index.html` file showcases a wireframe with the following sections:
+
+1. **Landing** – headline, subheading and a "Start Planning" button.
+2. **Setup Form** – inputs for the number of days, language, platforms, image prompts, content category and tone.
+3. **Result Preview** – summary of generated posts with an "Open Content Calendar" button.
+4. **Output View** – a basic table layout for daily content details.
+5. **Footer** – placeholder links for sharing and exporting data.
+
+Open `index.html` in your browser to preview the layout.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,119 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>PostPal</title>
+<style>
+body {font-family: Arial, sans-serif; margin:0; padding:0;}
+section {padding:40px;}
+header, footer {background:#f8f8f8; text-align:center; padding:20px;}
+button {padding:10px 20px;}
+form div {margin-bottom:10px;}
+.table {width:100%; border-collapse:collapse;}
+.table th, .table td {border:1px solid #ccc; padding:8px;}
+</style>
+</head>
+<body>
+<header>
+  <h1>Create Your AI-Powered Social Media Content Calendar</h1>
+  <p>Custom posts. Multiple platforms. Zero stress.</p>
+  <button>Start Planning</button>
+</header>
+
+<section id="setup">
+  <h2>Setup</h2>
+  <form>
+    <div>
+      <label>Number of days
+        <input type="number" name="days" min="1" />
+      </label>
+    </div>
+    <div>
+      <label>Language
+        <select name="language">
+          <option>English</option>
+          <option>Romanian</option>
+        </select>
+      </label>
+    </div>
+    <div>
+      <p>Social media platforms</p>
+      <label><input type="checkbox" name="platform" value="instagram" /> Instagram</label>
+      <label><input type="checkbox" name="platform" value="facebook" /> Facebook</label>
+      <label><input type="checkbox" name="platform" value="x" /> X</label>
+      <label><input type="checkbox" name="platform" value="pinterest" /> Pinterest</label>
+      <label><input type="checkbox" name="platform" value="tiktok" /> TikTok</label>
+    </div>
+    <div>
+      <p>Generate image prompts for</p>
+      <label><input type="checkbox" name="prompt" value="dalle" /> DALL·E</label>
+      <label><input type="checkbox" name="prompt" value="midjourney" /> Midjourney</label>
+      <label><input type="checkbox" name="prompt" value="canva" /> Canva</label>
+    </div>
+    <div>
+      <label>Content category
+        <select name="category">
+          <option>Educational</option>
+          <option>Entertaining</option>
+          <option>Promotional</option>
+        </select>
+      </label>
+    </div>
+    <div>
+      <label>Content tone
+        <select name="tone">
+          <option>Friendly</option>
+          <option>Funny</option>
+          <option>Professional</option>
+        </select>
+      </label>
+    </div>
+    <div>
+      <label>Theme (optional)
+        <input type="text" name="theme" />
+      </label>
+    </div>
+  </form>
+</section>
+
+<section id="preview">
+  <h2>Preview</h2>
+  <p>You've generated <strong>[X]</strong> posts for <strong>[Y]</strong> days</p>
+  <button>Open Content Calendar</button>
+</section>
+
+<section id="output">
+  <h2>Content Calendar</h2>
+  <table class="table">
+    <thead>
+      <tr>
+        <th>Date</th>
+        <th>Theme</th>
+        <th>Platforms</th>
+        <th>Hashtags</th>
+        <th>Image Prompts</th>
+        <th>Tags</th>
+        <th>Actions</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>2024-01-01</td>
+        <td>New Year</td>
+        <td>[Blocks]</td>
+        <td>#newyear</td>
+        <td>DALL·E: prompt</td>
+        <td>Educational, Friendly</td>
+        <td><button>Copy</button></td>
+      </tr>
+    </tbody>
+  </table>
+</section>
+
+<footer>
+  <p><a href="#">Shareable Airtable link</a></p>
+  <button>Export CSV</button>
+</footer>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create `index.html` with a simple layout for the landing page, setup form, result preview, output view and footer
- update README with instructions for viewing the prototype

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684c3914d83c8323b527f0a518d2e699